### PR TITLE
Fixed User ident regex to understand "-"

### DIFF
--- a/asyncirc/ircbot.py
+++ b/asyncirc/ircbot.py
@@ -20,7 +20,7 @@ else:
 from .ircclient import IRCClient
 
 #Somewhat complex regex that accurately matches nick!username@host, with named groups for easy parsing and usage
-user_re = re.compile(r'(?P<nick>[\w\d<-\[\]\^\{\}\~]+)!(?P<user>[\w\d<-\[\]\^\{\}\~]+)@(?P<host>.+)')
+user_re = re.compile(r'(?P<nick>[\w\d<-\[\]\^\{\}\~\-]+)!(?P<user>[\w\d<-\[\]\^\{\}\~]+)@(?P<host>.+)')
 
 class IRCBot(IRCClient):
     '''See `IRCClient` for basic client usage, here is usage for the bot system


### PR DESCRIPTION
Hi,

once again, if you have a `-` in your nickname, the nick will be cutted off, which ends up in priv_msg to that user does not work. also mentions does not work. 

